### PR TITLE
Fix redis async exceptions import

### DIFF
--- a/app/core/cache.py
+++ b/app/core/cache.py
@@ -19,6 +19,11 @@ from typing import Tuple
 from functools import wraps
 
 import redis.asyncio as redis
+from redis.exceptions import (
+    BusyLoadingError,
+    ConnectionError as RedisConnectionError,
+    TimeoutError as RedisTimeoutError,
+)
 import structlog
 from redis.retry import Retry
 from redis.backoff import ExponentialBackoff
@@ -58,9 +63,9 @@ class RedisConfig:
             "health_check_interval": 30,
             "max_connections": self.max_connections,
             "retry_on_error": [
-                redis.exceptions.BusyLoadingError,
-                redis.exceptions.ConnectionError,
-                redis.exceptions.TimeoutError,
+                BusyLoadingError,
+                RedisConnectionError,
+                RedisTimeoutError,
             ],
             "retry": Retry(
                 backoff=ExponentialBackoff(),


### PR DESCRIPTION
Corrected Redis exception import path to resolve `AttributeError` during server startup.

The `redis.asyncio` module does not expose `exceptions` directly; they are available under `redis.exceptions`. This PR updates `app/core/cache.py` to import exceptions from the correct `redis.exceptions` module, fixing the `AttributeError: module 'redis.asyncio' has no attribute 'exceptions'`.

---
<a href="https://cursor.com/background-agent?bcId=bc-8a9560f6-5d85-4714-b377-15eef5c71b08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8a9560f6-5d85-4714-b377-15eef5c71b08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

