### PR TITLE
Fix missing aiofiles module for email

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -400,6 +400,7 @@ def setup_logging() -> None:
     configure(
         processors=[
             structlog.contextvars.merge_contextvars,
+            structlog.processors.add_logger_name,
             structlog.processors.add_log_level,
             structlog.processors.StackInfoRenderer(),
             structlog.processors.TimeStamper(fmt="iso"),

--- a/app/main.py
+++ b/app/main.py
@@ -95,6 +95,7 @@ def _check_runtime_dependencies() -> None:
         "redis",
         "rq",
         "telegram",
+        "aiofiles",  # used by app.services.email
     ]
     missing: Dict[str, str] = {}
     for module_name in required_modules:
@@ -158,7 +159,7 @@ async def lifespan(app: FastAPI):
         )
         logger.info("🧭 Routers registered")
     except Exception as e:
-        logger.error("❌ Failed to register routers", error=str(e))
+        logger.error("❌ Failed to register routers", error=str(e), exc_info=True)
         raise
 
     # Initialize database

--- a/requirements.txt
+++ b/requirements.txt
@@ -77,6 +77,7 @@ typer==0.15.1                        # CLI commands
 rich==13.9.4                         # Rich terminal output
 pendulum==3.0.0                      # Better datetime handling
 pycountry==24.6.1                    # Country/language codes
+aiofiles==24.1.0                     # Async file IO (required by email service)
 
 # Retry utilities (used by app.services.google)
 tenacity==9.0.0


### PR DESCRIPTION
Add `aiofiles` dependency and improve logging for better error visibility.

The `ModuleNotFoundError: No module named 'aiofiles'` was causing application startup failures. This PR adds `aiofiles` to `requirements.txt` and the runtime dependency check. Additionally, it enhances error logging for router registration with `exc_info=True` and includes logger names in structlog output, providing more detailed information for troubleshooting.

---
<a href="https://cursor.com/background-agent?bcId=bc-23f9c6fd-c0af-4990-8fa8-5a7b3ecb8d11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-23f9c6fd-c0af-4990-8fa8-5a7b3ecb8d11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

