### PR TITLE
Fix structlog add_logger_name error

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -400,8 +400,8 @@ def setup_logging() -> None:
     configure(
         processors=[
             structlog.contextvars.merge_contextvars,
-            structlog.processors.add_logger_name,
-            structlog.processors.add_log_level,
+            structlog.stdlib.add_logger_name,
+            structlog.stdlib.add_log_level,
             structlog.processors.StackInfoRenderer(),
             structlog.processors.TimeStamper(fmt="iso"),
             (


### PR DESCRIPTION
Update `structlog` processor paths to fix `AttributeError` during application startup.

`add_logger_name` and `add_log_level` were moved from `structlog.processors` to `structlog.stdlib` in `structlog` version 24, causing startup failures. This PR updates the logging configuration to use the correct module paths.

---
<a href="https://cursor.com/background-agent?bcId=bc-91180552-27df-4bb9-8d7c-4b9471b6641a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-91180552-27df-4bb9-8d7c-4b9471b6641a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

