### PR TITLE
Fix structlog logger name error

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -394,10 +394,9 @@ settings = get_settings()
 def setup_logging() -> None:
     """Configure structured logging for the application."""
     import structlog
-    from structlog import configure, get_logger
     
     # Configure structlog
-    configure(
+    structlog.configure(
         processors=[
             structlog.contextvars.merge_contextvars,
             structlog.stdlib.add_logger_name,
@@ -413,7 +412,7 @@ def setup_logging() -> None:
         wrapper_class=structlog.make_filtering_bound_logger(
             getattr(logging, settings.LOG_LEVEL.upper())
         ),
-        logger_factory=structlog.PrintLoggerFactory(),
+        logger_factory=structlog.stdlib.LoggerFactory(),
         cache_logger_on_first_use=True,
     )
     

--- a/app/main.py
+++ b/app/main.py
@@ -124,13 +124,12 @@ async def lifespan(app: FastAPI):
     
     Handles startup and shutdown events for proper resource management.
     """
+    # Setup logging early before any logger usage
+    setup_logging()
     logger = structlog.get_logger(__name__)
     
     # Startup
     logger.info("🚀 Starting Animal Rescue Bot application")
-    
-    # Setup logging
-    setup_logging()
     logger.info("📝 Logging configured", log_level=settings.LOG_LEVEL)
     
     # בדיקת תלויות לפני כל ייבוא/אתחול שעלול לדרוש אותן


### PR DESCRIPTION
Fix `AttributeError: 'PrintLogger' object has no attribute 'name'` by using `structlog.stdlib.LoggerFactory` and moving `setup_logging` before logger instantiation.

The `add_logger_name` processor expects a standard library logger with a `name` attribute, which `PrintLogger` lacks. Additionally, the logger was being accessed before `setup_logging` was called in the `lifespan` function.

---
<a href="https://cursor.com/background-agent?bcId=bc-a65e8d13-8a82-423e-835d-52d3f83f6f70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a65e8d13-8a82-423e-835d-52d3f83f6f70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

