### PR TITLE
Fix missing connection argument in startup

### DIFF
--- a/app/workers/jobs.py
+++ b/app/workers/jobs.py
@@ -24,7 +24,7 @@ from sqlalchemy import select, update, and_, or_
 from sqlalchemy.orm import selectinload
 
 from app.core.config import settings
-from app.core.cache import redis_client
+from app.core.cache import redis_client, redis_queue_sync
 from app.models.database import (
     async_session_maker, User, Organization, Report, Alert, Event,
     ReportStatus, AlertStatus, AlertChannel, EventType, UrgencyLevel,
@@ -1157,7 +1157,7 @@ def schedule_recurring_jobs():
     from rq_scheduler import Scheduler
     from datetime import time
     
-    scheduler = Scheduler(connection=redis_client.connection_pool.connection())
+    scheduler = Scheduler(connection=redis_queue_sync)
     
     # Daily cleanup at 2 AM
     scheduler.cron(


### PR DESCRIPTION
Switch RQ/Scheduler to use a synchronous Redis client to resolve `TypeError: __init__() missing 1 required positional argument: 'connection'`.

---
<a href="https://cursor.com/background-agent?bcId=bc-c8cd5097-0a7e-4b02-8986-73df9c7b1509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c8cd5097-0a7e-4b02-8986-73df9c7b1509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

