### PR TITLE
Fix import error in worker jobs

### DIFF
--- a/app/bot/handlers.py
+++ b/app/bot/handlers.py
@@ -46,7 +46,7 @@ from app.models.database import AnimalType, UrgencyLevel, ReportStatus, UserRole
 from app.services.nlp import NLPService
 from app.services.geocoding import GeocodingService
 from app.services.file_storage import FileStorageService
-from app.workers.jobs import process_new_report, send_alerts_for_report
+from app.workers.jobs import process_new_report
 from app.core.i18n import get_text, detect_language, set_user_language
 
 # =============================================================================
@@ -888,7 +888,6 @@ async def submit_report(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
         
         # Queue background jobs
         process_new_report.delay(str(report.id))
-        send_alerts_for_report.delay(str(report.id))
         
         # Success message
         success_text = get_text("report_submitted_success", lang).format(


### PR DESCRIPTION
Remove `send_alerts_for_report` import and usage from `app/bot/handlers.py` to fix `ImportError`.

The `send_alerts_for_report` function did not exist in `app/workers/jobs.py`, causing an `ImportError`. The `process_new_report` job already handles sending alerts via `send_organization_alert`, making the separate call redundant.

---
<a href="https://cursor.com/background-agent?bcId=bc-023aa658-945c-4282-97c5-c7cb8843d84e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-023aa658-945c-4282-97c5-c7cb8843d84e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

