### PR TITLE
Investigate error at gist url

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -541,6 +541,9 @@ async def health_check():
     try:
         db_health = await check_database_health()
         health_data["services"]["database"] = db_health
+        # Bubble up concise PostGIS status when available
+        if isinstance(db_health, dict) and "postgis" in db_health:
+            health_data["services"]["postgis"] = db_health["postgis"]
     except Exception as e:
         health_data["services"]["database"] = {
             "status": "unhealthy",


### PR DESCRIPTION
Add automatic PostGIS extension creation and expose its status in the health check to resolve geometry type errors.

The original error "type geometry does not exist" indicated that the PostGIS extension was not enabled in the PostgreSQL database, preventing the use of `geometry(POINT,4326)` columns. This PR ensures the extension is created upon application startup and provides a clear status in the `/health` endpoint for easier debugging.

---
<a href="https://cursor.com/background-agent?bcId=bc-86dfdf67-b238-4245-9ca2-0477e83d2e52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-86dfdf67-b238-4245-9ca2-0477e83d2e52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

