### PR TITLE
Investigate error at github gist

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -411,8 +411,22 @@ async def rate_limiting_middleware(request: Request, call_next):
     from app.core.rate_limit import check_rate_limit, RateLimitExceeded
     
     try:
-        # Skip rate limiting for health checks and metrics
-        if request.url.path in ["/health", "/metrics"]:
+        # Skip rate limiting for health checks, docs, static, and Telegram webhook
+        path = request.url.path
+        excluded = {
+            "/health",
+            "/metrics",
+            "/docs",
+            "/redoc",
+            "/openapi.json",
+            f"{settings.API_V1_PREFIX}/openapi.json",
+        }
+        if (
+            path in excluded
+            or path.startswith("/static")
+            or path.startswith("/uploads")
+            or path.startswith("/telegram/webhook")
+        ):
             return await call_next(request)
         
         # Get client identifier
@@ -426,14 +440,22 @@ async def rate_limiting_middleware(request: Request, call_next):
                 pass  # Fall back to IP-based limiting
         
         # Check rate limit
-        await check_rate_limit(client_id, request.url.path)
+        await check_rate_limit(client_id, path)
         
         return await call_next(request)
         
     except RateLimitExceeded as e:
-        raise HTTPException(
+        # Return structured 429 response without triggering 500 error handler logs
+        return JSONResponse(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-            detail=f"Rate limit exceeded. Try again in {e.retry_after} seconds.",
+            content={
+                "error": True,
+                "error_code": "RATE_LIMIT_EXCEEDED",
+                "message": f"Rate limit exceeded. Try again in {e.retry_after} seconds.",
+                "retry_after": e.retry_after,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "request_id": getattr(request.state, "request_id", None),
+            },
             headers={"Retry-After": str(e.retry_after)}
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,6 +78,7 @@ rich==13.9.4                         # Rich terminal output
 pendulum==3.0.0                      # Better datetime handling
 pycountry==24.6.1                    # Country/language codes
 aiofiles==24.1.0                     # Async file IO (required by email service)
+psutil==5.9.8                        # System metrics (used by workers manager)
 
 # Retry utilities (used by app.services.google)
 tenacity==9.0.0


### PR DESCRIPTION
Enable Telegram bot polling when webhook is disabled, exclude webhook from rate limiting, and add `psutil` to fix bot unresponsiveness and worker startup.

The bot was not responding because polling was not correctly initiated when the webhook was not configured. Additionally, the rate limiting middleware was blocking incoming Telegram webhook requests, leading to 429 errors. The `psutil` dependency was also missing, causing worker startup failures. This PR addresses these issues by ensuring polling starts correctly, exempting the webhook path from rate limits, adding the missing dependency, improving the 429 error response, and adding graceful bot shutdown.

---
<a href="https://cursor.com/background-agent?bcId=bc-f1ff6162-9ee3-47c0-ac19-ab45df558501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f1ff6162-9ee3-47c0-ac19-ab45df558501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

