### PR TITLE
Investigate error from gist

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -672,7 +672,7 @@ async def version_info():
 # =============================================================================
 
 # Serve uploaded files (only in development)
-    if settings.is_development:
+if settings.is_development:
     uploads_dir = settings.UPLOAD_DIR
     uploads_dir.mkdir(exist_ok=True)
     app.mount("/uploads", StaticFiles(directory=uploads_dir), name="uploads")


### PR DESCRIPTION
Fix `IndentationError` in `app/main.py` by correcting the indentation of the `if settings.is_development:` block.

---
<a href="https://cursor.com/background-agent?bcId=bc-255130d9-f871-4771-ad69-3d335e52fad4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-255130d9-f871-4771-ad69-3d335e52fad4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

