### PR TITLE
Fix bot language and response issue

### DIFF
--- a/app/translations/ar.json
+++ b/app/translations/ar.json
@@ -71,5 +71,8 @@
   "alert.new_report.subject": "بلاغ إنقاذ حيوانات جديد",
   "alert.new_report.body": "تم استلام بلاغ إنقاذ جديد.",
 
-  "alert.status_update.subject": "تحديث الحالة: {status}"
+  "alert.status_update.subject": "تحديث الحالة: {status}",
+
+  "language_select_title": "اختر اللغة:",
+  "language_changed": "تم تعيين اللغة إلى {language} ✅"
 }

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -68,5 +68,8 @@
   "api.not_found": "Resource not found",
   "alert.new_report.subject": "New Animal Rescue Report",
   "alert.new_report.body": "A new animal rescue report has been submitted.",
-  "alert.status_update.subject": "Status update: {status}"
+  "alert.status_update.subject": "Status update: {status}",
+
+  "language_select_title": "Choose a language:",
+  "language_changed": "Language set to {language} ✅"
 }

--- a/app/translations/he.json
+++ b/app/translations/he.json
@@ -71,5 +71,8 @@
   "alert.new_report.subject": "דיווח הצלת בעלי חיים חדש",
   "alert.new_report.body": "התקבל דיווח הצלה חדש.",
 
-  "alert.status_update.subject": "עדכון סטטוס: {status}"
+  "alert.status_update.subject": "עדכון סטטוס: {status}",
+
+  "language_select_title": "בחר שפה:",
+  "language_changed": "השפה עודכנה ל‑{language} ✅"
 }


### PR DESCRIPTION
Set Hebrew as the default language and implement a functional language selection feature.

The bot previously lacked a mechanism to set a default language and the 'change language' button was not handled, leading to a poor user experience for Hebrew speakers.

---
<a href="https://cursor.com/background-agent?bcId=bc-1351830c-c496-40d4-8d7e-c7f5d2d8daf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1351830c-c496-40d4-8d7e-c7f5d2d8daf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

