### PR TITLE
Manual address entry causing bot failure

### DIFF
--- a/app/bot/handlers.py
+++ b/app/bot/handlers.py
@@ -2739,7 +2739,7 @@ async def handle_admin_add_org(update: Update, context: ContextTypes.DEFAULT_TYP
     await query.answer()
     lang = get_user_language(context)
     context.user_data["add_org"] = {"step": "name"}
-    await query.edit_message_text(get_text("add_organization", lang) + "\n\n" + get_text("enter_address_manually", lang))
+    await query.edit_message_text(get_text("add_organization", lang) + "\n\n" + get_text("prompt_org_name", lang))
 
 
 async def handle_admin_add_org_name_input(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -2755,7 +2755,7 @@ async def handle_admin_add_org_name_input(update: Update, context: ContextTypes.
     keyboard = []
     for t in [OrganizationType.VET_CLINIC, OrganizationType.EMERGENCY_VET, OrganizationType.ANIMAL_HOSPITAL, OrganizationType.ANIMAL_SHELTER, OrganizationType.RESCUE_ORG, OrganizationType.GOVERNMENT, OrganizationType.VOLUNTEER_GROUP]:
         keyboard.append([InlineKeyboardButton(t.value, callback_data=f"admin_add_org_type_{t.value}")])
-    await update.message.reply_text(get_text("orgs_management_title", lang), reply_markup=InlineKeyboardMarkup(keyboard))
+    await update.message.reply_text(get_text("select_org_type", lang), reply_markup=InlineKeyboardMarkup(keyboard))
 
 
 async def handle_admin_add_org_type(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/app/translations/ar.json
+++ b/app/translations/ar.json
@@ -75,4 +75,16 @@
 
   "language_select_title": "اختر اللغة:",
   "language_changed": "تم تعيين اللغة إلى {language} ✅"
+,
+  "orgs_management_title": "إدارة المنظمات",
+  "pending_org_approvals": "🕐 منظمات بانتظار الموافقة",
+  "active_organizations": "✅ منظمات نشطة",
+  "add_organization": "➕ إضافة منظمة جديدة",
+  "prompt_org_name": "أدخل اسم المنظمة الجديدة:",
+  "select_org_type": "اختر نوع المنظمة:",
+  "org_performance": "📈 أداء المنظمات",
+  "approve_organization": "الموافقة على المنظمة",
+  "reject_organization": "رفض الطلب",
+  "org_approved": "تمت الموافقة على {name} ✅",
+  "org_rejected": "تم رفض طلب {name} ❌"
 }

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -72,4 +72,16 @@
 
   "language_select_title": "Choose a language:",
   "language_changed": "Language set to {language} ✅"
+,
+  "orgs_management_title": "Organizations Management",
+  "pending_org_approvals": "🕐 Pending organization approvals",
+  "active_organizations": "✅ Active organizations",
+  "add_organization": "➕ Add new organization",
+  "prompt_org_name": "Enter new organization name:",
+  "select_org_type": "Choose organization type:",
+  "org_performance": "📈 Organization performance",
+  "approve_organization": "Approve organization",
+  "reject_organization": "Reject request",
+  "org_approved": "Organization {name} approved ✅",
+  "org_rejected": "Organization request {name} rejected ❌"
 }

--- a/app/translations/he.json
+++ b/app/translations/he.json
@@ -209,6 +209,8 @@
   "pending_org_approvals": "🕐 ארגונים ממתינים לאישור",
   "active_organizations": "✅ ארגונים פעילים",
   "add_organization": "➕ הוסף ארגון חדש",
+  "prompt_org_name": "הכנס שם ארגון חדש:",
+  "select_org_type": "בחר סוג ארגון:",
   "org_performance": "📈 ביצועי ארגונים",
   "approve_organization": "אשר ארגון",
   "reject_organization": "דחה בקשה",


### PR DESCRIPTION
Correct the "Add new organization" flow to prompt for an organization name instead of an address.

The bot previously prompted for an address and then became unresponsive when a name was entered, preventing new organizations from being added. This change clarifies the input steps for the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-44c6a984-e55c-418c-a9c9-f9c4feaff413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-44c6a984-e55c-418c-a9c9-f9c4feaff413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

