### PR TITLE
Add new animal welfare organization

### DIFF
--- a/app/bot/handlers.py
+++ b/app/bot/handlers.py
@@ -3480,6 +3480,11 @@ def create_bot_application() -> Application:
         filters.LOCATION,
         handle_service_area_location
     ))
+    # Admin add organization: capture name input early before generic text handlers
+    application.add_handler(MessageHandler(
+        filters.TEXT & ~filters.COMMAND,
+        handle_admin_add_org_name_input
+    ))
     # Handle text inputs for quiet hours and contact details
     application.add_handler(MessageHandler(
         filters.TEXT & ~filters.COMMAND,
@@ -3497,10 +3502,6 @@ def create_bot_application() -> Application:
     application.add_handler(MessageHandler(
         filters.TEXT & ~filters.COMMAND,
         handle_admin_search_input
-    ))
-    application.add_handler(MessageHandler(
-        filters.TEXT & ~filters.COMMAND,
-        handle_admin_add_org_name_input
     ))
     application.add_handler(MessageHandler(
         filters.TEXT & ~filters.COMMAND,


### PR DESCRIPTION
Move `handle_admin_add_org_name_input` handler registration earlier to correctly capture organization names.

The previous handler registration order caused the input for adding a new organization's name to be caught by more general text handlers, preventing the bot from responding. This change ensures the specific handler is processed first.

---
<a href="https://cursor.com/background-agent?bcId=bc-b40dd4e2-7b07-4ddf-8e27-25dfbfb17f06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b40dd4e2-7b07-4ddf-8e27-25dfbfb17f06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

