### PR TITLE
Fix telegram bot handler error

### DIFF
--- a/app/bot/handlers.py
+++ b/app/bot/handlers.py
@@ -3488,7 +3488,7 @@ def create_bot_application() -> Application:
     application.add_handler(MessageHandler(
         filters.TEXT & ~filters.COMMAND,
         handle_admin_add_org_name_input
-    ), block=False)
+    ))
     # Handle text inputs for quiet hours and contact details
     application.add_handler(MessageHandler(
         filters.TEXT & ~filters.COMMAND,


### PR DESCRIPTION
Remove `block=False` from `application.add_handler()` to fix `TypeError` during application startup.

The `block` parameter is no longer supported by `Application.add_handler()` in the current version of `python-telegram-bot`, causing a `TypeError` and preventing the application from starting. Removing it resolves this issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-b79e837d-e001-4f18-855a-f1fcc55c36b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b79e837d-e001-4f18-855a-f1fcc55c36b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

