### PR TITLE
Debug bot stuck after email or city input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
           ENVIRONMENT: testing
           TESTING: '1'
           TELEGRAM_BOT_TOKEN: 'test-token'
+          PYTHONPATH: ${{ github.workspace }}
         run: |
           python - <<'PY'
           import importlib
@@ -45,6 +46,8 @@ jobs:
           ENVIRONMENT: testing
           TESTING: '1'
           TELEGRAM_BOT_TOKEN: 'test-token'
+          PYTHONPATH: ${{ github.workspace }}
         run: |
+          export PYTHONPATH="$PWD"
           pytest -q
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:14
+        image: postgis/postgis:14-3.3
         ports:
           - 5432:5432
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main, master ]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Smoke import (no side effects)
+        env:
+          ENVIRONMENT: testing
+          TESTING: '1'
+          TELEGRAM_BOT_TOKEN: 'test-token'
+        run: |
+          python - <<'PY'
+          import importlib
+          import os
+          os.environ.setdefault('ENVIRONMENT','testing')
+          os.environ.setdefault('TESTING','1')
+          os.environ.setdefault('TELEGRAM_BOT_TOKEN','test-token')
+          importlib.import_module('app.main')
+          print('Imported app.main OK')
+          PY
+
+      - name: Run tests
+        env:
+          ENVIRONMENT: testing
+          TESTING: '1'
+          TELEGRAM_BOT_TOKEN: 'test-token'
+        run: |
+          pytest -q
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,22 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:14
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test_db
+        options: >-
+          --health-cmd "pg_isready -U postgres -d test_db"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test_db
     timeout-minutes: 20
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,25 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      - name: Init database schema
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test_db
+          ENVIRONMENT: testing
+          TESTING: '1'
+          TELEGRAM_BOT_TOKEN: 'test-token'
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          python - <<'PY'
+          import asyncio
+          import os
+          os.environ.setdefault('ENVIRONMENT','testing')
+          os.environ.setdefault('TESTING','1')
+          os.environ.setdefault('DATABASE_URL','postgresql+asyncpg://postgres:postgres@localhost:5432/test_db')
+          from app.models.database import create_tables
+          asyncio.run(create_tables())
+          print('DB schema initialized')
+          PY
+
       - name: Smoke import (no side effects)
         env:
           ENVIRONMENT: testing
@@ -53,6 +72,7 @@ jobs:
           os.environ.setdefault('ENVIRONMENT','testing')
           os.environ.setdefault('TESTING','1')
           os.environ.setdefault('TELEGRAM_BOT_TOKEN','test-token')
+          os.environ.setdefault('DATABASE_URL','postgresql+asyncpg://postgres:postgres@localhost:5432/test_db')
           importlib.import_module('app.main')
           print('Imported app.main OK')
           PY
@@ -65,5 +85,6 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}
         run: |
           export PYTHONPATH="$PWD"
+          export DATABASE_URL="postgresql+asyncpg://postgres:postgres@localhost:5432/test_db"
           pytest -q
 

--- a/app/bot/handlers.py
+++ b/app/bot/handlers.py
@@ -3423,18 +3423,18 @@ async def handle_language_selection(update: Update, context: ContextTypes.DEFAUL
         ],
     ]
     reply_markup = ReplyKeyboardMarkup(keyboard, resize_keyboard=True, one_time_keyboard=False)
-        # Build a friendly name with fallbacks if first_name is missing
-        _eu = update.effective_user
-        _name = (
-            getattr(_eu, "first_name", None)
-            or getattr(_eu, "full_name", None)
-            or getattr(_eu, "username", None)
-            or "משתמש"
-        )
-        welcome = get_text("welcome_message", lang_code).format(
-            name=_name,
-            app_name=settings.APP_NAME,
-        )
+    # Build a friendly name with fallbacks if first_name is missing
+    _eu = update.effective_user
+    _name = (
+        getattr(_eu, "first_name", None)
+        or getattr(_eu, "full_name", None)
+        or getattr(_eu, "username", None)
+        or "משתמש"
+    )
+    welcome = get_text("welcome_message", lang_code).format(
+        name=_name,
+        app_name=settings.APP_NAME,
+    )
     await query.message.reply_text(welcome, reply_markup=reply_markup, parse_mode=ParseMode.HTML)
 
 

--- a/app/bot/handlers.py
+++ b/app/bot/handlers.py
@@ -3402,6 +3402,8 @@ async def handle_language_selection(update: Update, context: ContextTypes.DEFAUL
     db_user = await get_or_create_user(update.effective_user)
     await set_user_language(db_user.id, lang_code)
     context.user_data[USER_DATA_KEYS["language"]] = lang_code
+    # Also store under plain key for compatibility with tests/consumers
+    context.user_data["language"] = lang_code
 
     lang_names = {"he": "עברית", "en": "English", "ar": "العربية"}
     ack = get_text("language_changed", lang_code).format(language=lang_names.get(lang_code, lang_code))

--- a/app/bot/handlers.py
+++ b/app/bot/handlers.py
@@ -2666,7 +2666,7 @@ async def handle_admin_import_google_input(update: Update, context: ContextTypes
             logger.error("import_google_city_failed", city=city, error=str(e))
             await update.message.reply_text(f"שגיאה בייבוא: {e}")
             context.user_data.pop("awaiting_google_city", None)
-            return
+            return ConversationHandler.END
 
         # Clear flag and report result
         context.user_data.pop("awaiting_google_city", None)

--- a/app/bot/handlers.py
+++ b/app/bot/handlers.py
@@ -3423,10 +3423,18 @@ async def handle_language_selection(update: Update, context: ContextTypes.DEFAUL
         ],
     ]
     reply_markup = ReplyKeyboardMarkup(keyboard, resize_keyboard=True, one_time_keyboard=False)
-    welcome = get_text("welcome_message", lang_code).format(
-        name=update.effective_user.first_name or "משתמש",
-        app_name=settings.APP_NAME,
-    )
+        # Build a friendly name with fallbacks if first_name is missing
+        _eu = update.effective_user
+        _name = (
+            getattr(_eu, "first_name", None)
+            or getattr(_eu, "full_name", None)
+            or getattr(_eu, "username", None)
+            or "משתמש"
+        )
+        welcome = get_text("welcome_message", lang_code).format(
+            name=_name,
+            app_name=settings.APP_NAME,
+        )
     await query.message.reply_text(welcome, reply_markup=reply_markup, parse_mode=ParseMode.HTML)
 
 

--- a/app/bot/handlers.py
+++ b/app/bot/handlers.py
@@ -2595,6 +2595,9 @@ async def handle_admin_import_location_inputs(update: Update, context: ContextTy
         )
         return ConversationHandler.END
 
+    # If we got here, input wasn't a known radius or a location – keep waiting in the same state
+    return ADMIN_IMPORT_LOCATION_INPUT
+
 
 async def handle_admin_import_google_input(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     # Guard: only act when awaiting city input

--- a/app/bot/handlers.py
+++ b/app/bot/handlers.py
@@ -63,6 +63,19 @@ from app.core.i18n import get_text, detect_language, set_user_language, get_user
     SELECTING_ANIMAL_TYPE,
 ) = range(6)
 
+# Admin: Add Organization conversation states (use distinct values to avoid collisions)
+(
+    ADMIN_ADD_ORG_NAME,
+    ADMIN_ADD_ORG_TYPE,
+    ADMIN_ADD_ORG_EMAIL,
+) = range(100, 103)
+
+# Admin: Import flows conversation states
+(
+    ADMIN_IMPORT_GOOGLE_CITY,
+    ADMIN_IMPORT_LOCATION_INPUT,
+) = range(103, 105)
+
 # User session data keys
 USER_DATA_KEYS = {
     "report_draft": "current_report",
@@ -2475,16 +2488,18 @@ async def handle_admin_active_orgs(update: Update, context: ContextTypes.DEFAULT
     await query.edit_message_text(text, reply_markup=InlineKeyboardMarkup(keyboard))
 
 
-async def handle_admin_import_google(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+async def handle_admin_import_google(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     query = update.callback_query
     await query.answer()
     lang = get_user_language(context)
     logger.info("enter_handle_admin_import_google", user_id=getattr(update.effective_user, "id", None), chat_id=getattr(update.effective_chat, "id", None))
     context.user_data["awaiting_google_city"] = True
     await query.edit_message_text("הכנס שם עיר לייבוא קליניקות ומקלטים (באנגלית/עברית)")
+    logger.info("enter state=google_city", flow="admin_import_google")
+    return ADMIN_IMPORT_GOOGLE_CITY
 
 
-async def handle_admin_import_location(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+async def handle_admin_import_location(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     query = update.callback_query
     await query.answer()
     lang = get_user_language(context)
@@ -2497,9 +2512,11 @@ async def handle_admin_import_location(update: Update, context: ContextTypes.DEF
     ]
     await query.edit_message_text("שלח מיקום GPS ובחר רדיוס (5/10/20/50 ק""מ)")
     await query.message.reply_text("בחר רדיוס:", reply_markup=ReplyKeyboardMarkup(keyboard, resize_keyboard=True))
+    logger.info("enter state=import_location", flow="admin_import_location")
+    return ADMIN_IMPORT_LOCATION_INPUT
 
 
-async def handle_admin_import_location_inputs(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+async def handle_admin_import_location_inputs(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Collect location and radius, then import nearby orgs."""
     logger.info(
         "enter_handle_admin_import_location_inputs",
@@ -2510,7 +2527,7 @@ async def handle_admin_import_location_inputs(update: Update, context: ContextTy
         chat_id=getattr(update.effective_chat, "id", None),
     )
     if not context.user_data.get("awaiting_import_location"):
-        return
+        return ADMIN_IMPORT_LOCATION_INPUT
     lang = get_user_language(context)
     # Determine radius selection
     text = (getattr(update, 'message', None) and update.message.text or '')
@@ -2524,7 +2541,7 @@ async def handle_admin_import_location_inputs(update: Update, context: ContextTy
         context.user_data["import_radius_m"] = radius_map[text]
         logger.info("import_location_radius_selected", radius_m=radius_map[text])
         await update.message.reply_text("עכשיו שלח את המיקום שלך (כפתור 'שתף מיקום')")
-        return
+        return ADMIN_IMPORT_LOCATION_INPUT
     if getattr(update, 'message', None) and update.message.location:
         loc = update.message.location
         radius = int(context.user_data.get("import_radius_m", 10000))
@@ -2568,7 +2585,7 @@ async def handle_admin_import_location_inputs(update: Update, context: ContextTy
             await update.message.reply_text(f"שגיאה בייבוא: {e}")
             context.user_data.pop("awaiting_import_location", None)
             context.user_data.pop("import_radius_m", None)
-            return
+            return ConversationHandler.END
         context.user_data.pop("awaiting_import_location", None)
         context.user_data.pop("import_radius_m", None)
         logger.info("import_location_completed", created=created, radius_m=radius)
@@ -2576,9 +2593,10 @@ async def handle_admin_import_location_inputs(update: Update, context: ContextTy
             f"ייבוא לפי מיקום הושלם. נוספו {created} ארגונים חדשים ברדיוס {int(radius/1000)} ק""מ.",
             reply_markup=ReplyKeyboardRemove()
         )
+        return ConversationHandler.END
 
 
-async def handle_admin_import_google_input(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+async def handle_admin_import_google_input(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     # Guard: only act when awaiting city input
     logger.info(
         "enter_handle_admin_import_google_input",
@@ -2588,12 +2606,12 @@ async def handle_admin_import_google_input(update: Update, context: ContextTypes
         chat_id=getattr(update.effective_chat, "id", None),
     )
     if not context.user_data.get("awaiting_google_city"):
-        return
+        return ADMIN_IMPORT_GOOGLE_CITY
     lang = get_user_language(context)
     city = (getattr(update, 'message', None) and update.message.text or '').strip()
     if not city:
         await update.message.reply_text(get_text("invalid_input", lang))
-        return
+        return ADMIN_IMPORT_GOOGLE_CITY
 
     # Per-user concurrency lock to avoid parallel imports and race conditions
     user = update.effective_user
@@ -2601,7 +2619,7 @@ async def handle_admin_import_google_input(update: Update, context: ContextTypes
     async with lock:
         # Re-check flag after acquiring the lock in case another import already handled it
         if not context.user_data.get("awaiting_google_city"):
-            return
+            return ConversationHandler.END
 
         # Immediate feedback that import has started
         try:
@@ -2654,6 +2672,7 @@ async def handle_admin_import_google_input(update: Update, context: ContextTypes
         context.user_data.pop("awaiting_google_city", None)
         logger.info("import_google_city_completed", city=city, created=created)
         await update.message.reply_text(f"ייבוא מגוגל הושלם. נוספו {created} ארגונים חדשים בעיר {city}.")
+        return ConversationHandler.END
 
 
 # =============================================================================
@@ -2858,16 +2877,18 @@ async def handle_admin_geocode_orgs(update: Update, context: ContextTypes.DEFAUL
     await query.edit_message_text("הפעולה תוסף בקרוב: העשרת כתובות ארגונים בנתוני מיקום.")
 
 
-async def handle_admin_add_org(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+async def handle_admin_add_org(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     query = update.callback_query
     await query.answer()
     lang = get_user_language(context)
     logger.info("enter_handle_admin_add_org", user_id=getattr(update.effective_user, "id", None), chat_id=getattr(update.effective_chat, "id", None))
     context.user_data["add_org"] = {"step": "name"}
     await query.edit_message_text(get_text("add_organization", lang) + "\n\n" + get_text("prompt_org_name", lang))
+    logger.info("enter state=name", flow="admin_add_org")
+    return ADMIN_ADD_ORG_NAME
 
 
-async def handle_admin_add_org_name_input(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+async def handle_admin_add_org_name_input(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     logger.info(
         "enter_handle_admin_add_org_name_input",
         in_flow=bool(context.user_data.get("add_org")),
@@ -2876,13 +2897,14 @@ async def handle_admin_add_org_name_input(update: Update, context: ContextTypes.
         user_id=getattr(update.effective_user, "id", None),
         chat_id=getattr(update.effective_chat, "id", None),
     )
+    logger.info("enter state=name", flow="admin_add_org")
     if not context.user_data.get("add_org") or context.user_data.get("add_org", {}).get("step") != "name":
-        return
+        return ADMIN_ADD_ORG_NAME
     lang = get_user_language(context)
     name = (getattr(update, 'message', None) and update.message.text or '').strip()
     if not name:
         await update.message.reply_text(get_text("invalid_input", lang))
-        return
+        return ADMIN_ADD_ORG_NAME
     logger.info("add_org_name_captured", name=name)
     context.user_data["add_org"] = {"step": "type", "name": name}
     # Show type options
@@ -2891,9 +2913,11 @@ async def handle_admin_add_org_name_input(update: Update, context: ContextTypes.
         label = get_text(f"org_type_{t.value}", lang)
         keyboard.append([InlineKeyboardButton(label, callback_data=f"admin_add_org_type_{t.value}")])
     await update.message.reply_text(get_text("select_org_type", lang), reply_markup=InlineKeyboardMarkup(keyboard))
+    logger.info("enter state=type", flow="admin_add_org")
+    return ADMIN_ADD_ORG_TYPE
 
 
-async def handle_admin_add_org_email_input(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+async def handle_admin_add_org_email_input(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Collect organization email and create the organization."""
     logger.info(
         "enter_handle_admin_add_org_email_input",
@@ -2903,14 +2927,15 @@ async def handle_admin_add_org_email_input(update: Update, context: ContextTypes
         user_id=getattr(update.effective_user, "id", None),
         chat_id=getattr(update.effective_chat, "id", None),
     )
+    logger.info("enter state=email", flow="admin_add_org")
     if not context.user_data.get("add_org") or context.user_data.get("add_org", {}).get("step") != "email":
-        return
+        return ADMIN_ADD_ORG_EMAIL
     lang = get_user_language(context)
     text = (getattr(update, 'message', None) and update.message.text or '').strip()
     import re as _re
     if not _re.match(r"^[^\s@]+@[^\s@]+\.[^\s@]+$", text):
         await update.message.reply_text(get_text("invalid_email", lang))
-        return
+        return ADMIN_ADD_ORG_EMAIL
     logger.info("add_org_email_captured")
     add_ctx = context.user_data.get("add_org", {})
     name = add_ctx.get("name")
@@ -2928,9 +2953,10 @@ async def handle_admin_add_org_email_input(update: Update, context: ContextTypes
         await session.commit()
     context.user_data.pop("add_org", None)
     await update.message.reply_text(get_text("org_approved", lang).format(name=name))
+    return ConversationHandler.END
 
 
-async def handle_admin_add_org_type(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+async def handle_admin_add_org_type(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     logger.info(
         "enter_handle_admin_add_org_type",
         in_flow=bool(context.user_data.get("add_org")),
@@ -2938,8 +2964,9 @@ async def handle_admin_add_org_type(update: Update, context: ContextTypes.DEFAUL
         user_id=getattr(update.effective_user, "id", None),
         chat_id=getattr(update.effective_chat, "id", None),
     )
+    logger.info("enter state=type", flow="admin_add_org")
     if not context.user_data.get("add_org") or context.user_data.get("add_org", {}).get("step") != "type":
-        return
+        return ADMIN_ADD_ORG_TYPE
     query = update.callback_query
     await query.answer()
     lang = get_user_language(context)
@@ -2948,10 +2975,12 @@ async def handle_admin_add_org_type(update: Update, context: ContextTypes.DEFAUL
     name = context.user_data.get("add_org", {}).get("name")
     if not name:
         await query.edit_message_text(get_text("operation_failed", lang))
-        return
+        return ADMIN_ADD_ORG_TYPE
     # Move to email collection step before creation
     context.user_data["add_org"] = {"step": "email", "name": name, "org_type": org_type}
     await query.edit_message_text(get_text("email_instructions", lang))
+    logger.info("enter state=email", flow="admin_add_org")
+    return ADMIN_ADD_ORG_EMAIL
 
 
 async def handle_admin_org_performance(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -3497,6 +3526,60 @@ def create_bot_application() -> Application:
     # Add conversation handler for report creation
     report_handler = create_report_conversation_handler()
     application.add_handler(report_handler)
+
+    # Admin: Add Organization conversation handler
+    admin_add_org_conv = ConversationHandler(
+        entry_points=[
+            CallbackQueryHandler(handle_admin_add_org, pattern="^admin_add_org$")
+        ],
+        states={
+            ADMIN_ADD_ORG_NAME: [
+                MessageHandler(filters.TEXT & ~filters.COMMAND, handle_admin_add_org_name_input),
+            ],
+            ADMIN_ADD_ORG_TYPE: [
+                CallbackQueryHandler(handle_admin_add_org_type, pattern="^admin_add_org_type_.*$")
+            ],
+            ADMIN_ADD_ORG_EMAIL: [
+                MessageHandler(filters.TEXT & ~filters.COMMAND, handle_admin_add_org_email_input),
+            ],
+        },
+        fallbacks=[],
+        allow_reentry=True,
+        name="admin_add_org_conv",
+    )
+    application.add_handler(admin_add_org_conv)
+
+    # Admin: Import Google by city conversation handler
+    admin_import_google_conv = ConversationHandler(
+        entry_points=[
+            CallbackQueryHandler(handle_admin_import_google, pattern="admin_import_google")
+        ],
+        states={
+            ADMIN_IMPORT_GOOGLE_CITY: [
+                MessageHandler(filters.TEXT & ~filters.COMMAND, handle_admin_import_google_input),
+            ]
+        },
+        fallbacks=[],
+        allow_reentry=True,
+        name="admin_import_google_conv",
+    )
+    application.add_handler(admin_import_google_conv)
+
+    # Admin: Import by location conversation handler
+    admin_import_location_conv = ConversationHandler(
+        entry_points=[
+            CallbackQueryHandler(handle_admin_import_location, pattern="admin_import_location")
+        ],
+        states={
+            ADMIN_IMPORT_LOCATION_INPUT: [
+                MessageHandler((filters.TEXT | filters.LOCATION) & ~filters.COMMAND, handle_admin_import_location_inputs)
+            ]
+        },
+        fallbacks=[],
+        allow_reentry=True,
+        name="admin_import_location_conv",
+    )
+    application.add_handler(admin_import_location_conv)
     
     # Add callback handlers for various actions
     application.add_handler(CallbackQueryHandler(
@@ -3632,11 +3715,7 @@ def create_bot_application() -> Application:
     application.add_handler(CallbackQueryHandler(handle_admin_active_orgs, pattern="admin_active_orgs"))
     application.add_handler(CallbackQueryHandler(handle_admin_view_org, pattern="^admin_view_org_.*$"))
     # Add org flow callbacks
-    application.add_handler(CallbackQueryHandler(handle_admin_add_org, pattern="^admin_add_org$"))
-    application.add_handler(CallbackQueryHandler(handle_admin_add_org_type, pattern="^admin_add_org_type_.*$"))
-    application.add_handler(CallbackQueryHandler(handle_admin_add_org_type, pattern="admin_add_org_type_.*"))
-    application.add_handler(CallbackQueryHandler(handle_admin_import_google, pattern="admin_import_google"))
-    application.add_handler(CallbackQueryHandler(handle_admin_import_location, pattern="admin_import_location"))
+    # Note: moved add_org/import flows under ConversationHandlers below to avoid duplicate handling
     application.add_handler(CallbackQueryHandler(handle_admin_manage_import_cities, pattern="admin_import_cities"))
     application.add_handler(CallbackQueryHandler(handle_admin_import_cities_add, pattern="admin_import_cities_add"))
     application.add_handler(CallbackQueryHandler(handle_admin_import_cities_remove, pattern="admin_import_cities_remove"))
@@ -3660,12 +3739,7 @@ def create_bot_application() -> Application:
         handle_service_area_location,
         block=False
     ))
-    # Admin add organization: capture name input early before generic text handlers
-    application.add_handler(MessageHandler(
-        filters.TEXT & ~filters.COMMAND,
-        handle_admin_add_org_name_input,
-        block=False
-    ))
+    # Note: name/email inputs for add_org handled by ConversationHandler states – avoid duplicate catch-all
     # Handle text inputs for quiet hours and contact details
     application.add_handler(MessageHandler(
         filters.TEXT & ~filters.COMMAND,
@@ -3693,22 +3767,7 @@ def create_bot_application() -> Application:
         handle_admin_broadcast_input,
         block=False
     ))
-    application.add_handler(MessageHandler(
-        filters.TEXT & ~filters.COMMAND,
-        handle_admin_import_google_input,
-        block=False
-    ))
-    # Admin add organization email input
-    application.add_handler(MessageHandler(
-        filters.TEXT & ~filters.COMMAND,
-        handle_admin_add_org_email_input,
-        block=False
-    ))
-    application.add_handler(MessageHandler(
-        (filters.TEXT | filters.LOCATION) & ~filters.COMMAND,
-        handle_admin_import_location_inputs,
-        block=False
-    ))
+    # Note: import google/location inputs handled by ConversationHandler states – avoid duplicate catch-all
     application.add_handler(MessageHandler(
         filters.TEXT & ~filters.COMMAND,
         handle_admin_import_cities_inputs,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_default_fixture_loop_scope = function
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -96,3 +96,9 @@ gunicorn==23.0.0                     # WSGI server for production
 GeoAlchemy2==0.18.0              # GIS support for PostgreSQL
 itsdangerous==2.2.0
 
+# =============================================================================
+# Testing (installed in CI/runtime for simplicity)
+# =============================================================================
+pytest==8.3.3
+pytest-asyncio==0.24.0
+

--- a/tests/test_admin_flows.py
+++ b/tests/test_admin_flows.py
@@ -19,6 +19,7 @@ from app.bot.handlers import (
     show_admin_orgs_menu,
 )
 from telegram.ext import ConversationHandler
+from telegram import ReplyKeyboardRemove
 
 
 class MsgStub:
@@ -392,6 +393,9 @@ async def test_import_location_success_flow():
             assert "awaiting_import_location" not in ctx.user_data
             assert "import_radius_m" not in ctx.user_data
             assert msg_loc.calls  # completion reply
+            # Ensure keyboard is removed
+            rm = msg_loc.calls[-1][1].get("reply_markup")
+            assert isinstance(rm, ReplyKeyboardRemove)
 
 
 @pytest.mark.asyncio

--- a/tests/test_admin_flows.py
+++ b/tests/test_admin_flows.py
@@ -1,0 +1,225 @@
+import types
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from app.bot.handlers import (
+    ADMIN_ADD_ORG_NAME,
+    ADMIN_ADD_ORG_TYPE,
+    ADMIN_ADD_ORG_EMAIL,
+    ADMIN_IMPORT_GOOGLE_CITY,
+    ADMIN_IMPORT_LOCATION_INPUT,
+    handle_admin_import_google_input,
+    handle_admin_import_location_inputs,
+    handle_admin_import_google,
+    handle_admin_import_location,
+    handle_admin_add_org,
+    handle_admin_add_org_name_input,
+    handle_admin_add_org_type,
+    handle_admin_add_org_email_input,
+)
+from telegram.ext import ConversationHandler
+
+
+class MsgStub:
+    def __init__(self, text=None, location=None):
+        self.text = text
+        self.location = location
+        self.calls = []
+        self.chat = types.SimpleNamespace(id=1)
+
+    async def reply_text(self, *a, **k):
+        self.calls.append((a, k))
+
+
+class CqStub:
+    def __init__(self, data=""):
+        self.data = data
+        self.message = types.SimpleNamespace(message_id=1)
+        self.answered = False
+        self.edited = []
+
+    async def answer(self):
+        self.answered = True
+
+    async def edit_message_text(self, *a, **k):
+        self.edited.append((a, k))
+
+
+def make_context():
+    return types.SimpleNamespace(user_data={})
+
+
+@pytest.mark.asyncio
+async def test_import_google_city_failure_ends_conversation():
+    ctx = make_context()
+    ctx.user_data["awaiting_google_city"] = True
+    update = types.SimpleNamespace(message=MsgStub(text="רעננה"), effective_user=None, effective_chat=None)
+
+    class _DummyGoogle:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+        async def search_veterinary_clinics(self, city: str):
+            raise RuntimeError("API down")
+        async def search_animal_shelters(self, city: str):
+            return []
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+        async def execute(self, *a, **k):
+            class _R:
+                def scalar_one_or_none(self_inner):
+                    return None
+            return _R()
+        def add(self, *a, **k):
+            return None
+        async def commit(self):
+            return None
+
+    with patch("app.services.google.GoogleService", return_value=_DummyGoogle()):
+        with patch("app.bot.handlers.async_session_maker", return_value=_FakeSession()):
+            res = await handle_admin_import_google_input(update, ctx)
+            assert res == ConversationHandler.END
+            assert "awaiting_google_city" not in ctx.user_data
+            assert update.message.calls  # replied with error
+
+
+@pytest.mark.asyncio
+async def test_import_location_failure_ends_conversation():
+    ctx = make_context()
+    ctx.user_data["awaiting_import_location"] = True
+    ctx.user_data["import_radius_m"] = 5000
+
+    class _Loc:  # simple location stub
+        latitude = 32.184
+        longitude = 34.871
+
+    update = types.SimpleNamespace(message=MsgStub(location=_Loc()), effective_user=None, effective_chat=None)
+
+    class _DummyGoogle:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+        async def search_veterinary_nearby(self, loc, radius: int):
+            raise RuntimeError("network")
+        async def search_shelters_nearby(self, loc, radius: int):
+            return []
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+        async def execute(self, *a, **k):
+            class _R:
+                def scalar_one_or_none(self_inner):
+                    return None
+            return _R()
+        def add(self, *a, **k):
+            return None
+        async def commit(self):
+            return None
+
+    with patch("app.services.google.GoogleService", return_value=_DummyGoogle()):
+        with patch("app.bot.handlers.async_session_maker", return_value=_FakeSession()):
+            res = await handle_admin_import_location_inputs(update, ctx)
+            assert res == ConversationHandler.END
+            assert "awaiting_import_location" not in ctx.user_data
+            assert "import_radius_m" not in ctx.user_data
+            assert update.message.calls  # replied with error
+
+
+@pytest.mark.asyncio
+async def test_add_org_happy_path():
+    ctx = make_context()
+    # Start via callback
+    cq = CqStub(data="admin_add_org")
+    update_cq = types.SimpleNamespace(callback_query=cq, effective_user=None, effective_chat=None)
+    state = await handle_admin_add_org(update_cq, ctx)
+    assert state == ADMIN_ADD_ORG_NAME
+    assert ctx.user_data["add_org"]["step"] == "name"
+
+    # Provide name
+    msg = MsgStub(text="צער בעלי חיים תל אביב")
+    update_msg = types.SimpleNamespace(message=msg, effective_user=None, effective_chat=None)
+    state = await handle_admin_add_org_name_input(update_msg, ctx)
+    assert state == ADMIN_ADD_ORG_TYPE
+    assert ctx.user_data["add_org"]["step"] == "type"
+    assert ctx.user_data["add_org"]["name"]
+
+    # Choose type
+    cq2 = CqStub(data="admin_add_org_type_animal_shelter")
+    update_cq2 = types.SimpleNamespace(callback_query=cq2, effective_user=None, effective_chat=None)
+    state = await handle_admin_add_org_type(update_cq2, ctx)
+    assert state == ADMIN_ADD_ORG_EMAIL
+    assert ctx.user_data["add_org"]["step"] == "email"
+
+    # Send email and commit
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+        def add(self, *a, **k):
+            return None
+        async def commit(self):
+            return None
+
+    with patch("app.bot.handlers.async_session_maker", return_value=_FakeSession()):
+        msg2 = MsgStub(text="amir@example.com")
+        update_msg2 = types.SimpleNamespace(message=msg2, effective_user=None, effective_chat=None)
+        end = await handle_admin_add_org_email_input(update_msg2, ctx)
+        assert end == ConversationHandler.END
+        assert "add_org" not in ctx.user_data
+
+
+@pytest.mark.asyncio
+async def test_import_google_city_success_flow():
+    ctx = make_context()
+    # Start via callback
+    cq = CqStub(data="admin_import_google")
+    update_cq = types.SimpleNamespace(callback_query=cq, effective_user=None, effective_chat=None)
+    # Move to awaiting city state
+    state = await handle_admin_import_google(update_cq, ctx)
+    assert state == ADMIN_IMPORT_GOOGLE_CITY
+    assert ctx.user_data.get("awaiting_google_city") is True
+
+    # Prepare success google mock
+    class _DummyGoogle:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+        async def search_veterinary_clinics(self, city: str):
+            return [{"name": "Vet A", "place_id": "p1"}]
+        async def search_animal_shelters(self, city: str):
+            return [{"name": "Shelter B", "place_id": "p2"}]
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+        async def execute(self, *a, **k):
+            class _R:
+                def scalar_one_or_none(self_inner):
+                    return None
+            return _R()
+        def add(self, *a, **k):
+            return None
+        async def commit(self):
+            return None
+
+    with patch("app.services.google.GoogleService", return_value=_DummyGoogle()):
+        with patch("app.bot.handlers.async_session_maker", return_value=_FakeSession()):
+            msg = MsgStub(text="רעננה")
+            update_msg = types.SimpleNamespace(message=msg, effective_user=None, effective_chat=None)
+            end = await handle_admin_import_google_input(update_msg, ctx)
+            assert end == ConversationHandler.END
+            assert "awaiting_google_city" not in ctx.user_data
+            assert msg.calls  # some reply was sent

--- a/tests/test_admin_flows.py
+++ b/tests/test_admin_flows.py
@@ -315,6 +315,9 @@ async def test_add_org_invalid_email_stays_in_state():
     assert res == ADMIN_ADD_ORG_EMAIL
     assert ctx.user_data["add_org"]["step"] == "email"
     assert msg.calls  # invalid email reply
+    # Validate i18n text contains Hebrew invalid_email
+    last_text = msg.calls[-1][0][0]
+    assert "כתובת אימייל לא תקינה" in last_text
 
 
 @pytest.mark.asyncio

--- a/tests/test_admin_flows.py
+++ b/tests/test_admin_flows.py
@@ -106,6 +106,7 @@ async def test_show_admin_orgs_menu_permission_denied():
         await show_admin_orgs_menu(update, ctx)
         # Should reply with permission_denied message (some text)
         assert msg.calls
+        assert "אין לך הרשאה לבצע פעולה זו" in msg.calls[-1][0][0]
 
 
 
@@ -265,6 +266,7 @@ async def test_import_google_empty_city_stays_in_state():
     res = await handle_admin_import_google_input(update, ctx)
     assert res == ADMIN_IMPORT_GOOGLE_CITY
     assert update.message.calls  # invalid input reply
+    assert "קלט לא תקין" in update.message.calls[-1][0][0]
 
 
 @pytest.mark.asyncio

--- a/tests/test_admin_flows.py
+++ b/tests/test_admin_flows.py
@@ -34,7 +34,8 @@ class MsgStub:
 class CqStub:
     def __init__(self, data=""):
         self.data = data
-        self.message = types.SimpleNamespace(message_id=1)
+        # Use MsgStub so handlers can call query.message.reply_text(...)
+        self.message = MsgStub()
         self.answered = False
         self.edited = []
 

--- a/tests/test_admin_flows.py
+++ b/tests/test_admin_flows.py
@@ -237,6 +237,16 @@ async def test_import_google_input_guard_no_flag():
 
 
 @pytest.mark.asyncio
+async def test_import_google_empty_city_stays_in_state():
+    ctx = make_context()
+    ctx.user_data["awaiting_google_city"] = True
+    update = types.SimpleNamespace(message=MsgStub(text="   "), effective_user=None, effective_chat=None)
+    res = await handle_admin_import_google_input(update, ctx)
+    assert res == ADMIN_IMPORT_GOOGLE_CITY
+    assert update.message.calls  # invalid input reply
+
+
+@pytest.mark.asyncio
 async def test_import_location_input_guard_no_flag():
     # Text radius with no awaiting flag
     ctx = make_context()

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -48,6 +48,7 @@ async def test_handle_language_selection_updates_context():
             username="testuser",
             full_name="Test User",
             language_code="he",
+            first_name="Test",
         ),
     )
     # Patch i18n setter if needed

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,0 +1,49 @@
+import types
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from app.bot.handlers import show_language_menu, handle_language_selection
+
+
+class MsgStub:
+    def __init__(self):
+        self.calls = []
+    async def reply_text(self, *a, **k):
+        self.calls.append((a, k))
+
+
+class CqStub:
+    def __init__(self, data):
+        self.data = data
+        self.edited = []
+        self.answered = False
+        self.message = MsgStub()
+    async def answer(self):
+        self.answered = True
+    async def edit_message_text(self, *a, **k):
+        self.edited.append((a, k))
+
+
+def make_ctx():
+    return types.SimpleNamespace(user_data={})
+
+
+@pytest.mark.asyncio
+async def test_show_language_menu_sends_buttons():
+    ctx = make_ctx()
+    msg = MsgStub()
+    update = types.SimpleNamespace(message=msg)
+    await show_language_menu(update, ctx)
+    assert msg.calls
+
+
+@pytest.mark.asyncio
+async def test_handle_language_selection_updates_context():
+    ctx = make_ctx()
+    cq = CqStub("set_lang_en")
+    update = types.SimpleNamespace(callback_query=cq)
+    # Patch i18n setter if needed
+    with patch("app.bot.handlers.set_user_language", new=AsyncMock()) as set_lang:
+        await handle_language_selection(update, ctx)
+        # The preference should be stored in context
+        assert ctx.user_data.get("language") == "en"

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -41,7 +41,15 @@ async def test_show_language_menu_sends_buttons():
 async def test_handle_language_selection_updates_context():
     ctx = make_ctx()
     cq = CqStub("set_lang_en")
-    update = types.SimpleNamespace(callback_query=cq, effective_user=types.SimpleNamespace(id=12345))
+    update = types.SimpleNamespace(
+        callback_query=cq,
+        effective_user=types.SimpleNamespace(
+            id=12345,
+            username="testuser",
+            full_name="Test User",
+            language_code="he",
+        ),
+    )
     # Patch i18n setter if needed
     with patch("app.bot.handlers.set_user_language", new=AsyncMock()) as set_lang:
         await handle_language_selection(update, ctx)

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -41,7 +41,7 @@ async def test_show_language_menu_sends_buttons():
 async def test_handle_language_selection_updates_context():
     ctx = make_ctx()
     cq = CqStub("set_lang_en")
-    update = types.SimpleNamespace(callback_query=cq)
+    update = types.SimpleNamespace(callback_query=cq, effective_user=types.SimpleNamespace(id=12345))
     # Patch i18n setter if needed
     with patch("app.bot.handlers.set_user_language", new=AsyncMock()) as set_lang:
         await handle_language_selection(update, ctx)

--- a/tests/test_import_cities.py
+++ b/tests/test_import_cities.py
@@ -119,7 +119,7 @@ async def test_import_cities_run_summarizes():
                 return None
             async def commit(self):
                 return None
-        with patch("app.bot.handlers.GoogleService", return_value=_DummyGoogle()):
+        with patch("app.services.google.GoogleService", return_value=_DummyGoogle()):
             with patch("app.bot.handlers.async_session_maker", return_value=_FakeSession()):
                 await handle_admin_import_cities_run(update_cq, ctx)
                 # Should edit summary text with totals

--- a/tests/test_import_cities.py
+++ b/tests/test_import_cities.py
@@ -1,0 +1,128 @@
+import types
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from app.bot.handlers import (
+    handle_admin_manage_import_cities,
+    handle_admin_import_cities_add,
+    handle_admin_import_cities_remove,
+    handle_admin_import_cities_run,
+    handle_admin_import_cities_inputs,
+    IMPORT_CITIES_REDIS_KEY,
+)
+
+
+class MsgStub:
+    def __init__(self, text=None):
+        self.text = text
+        self.calls = []
+    async def reply_text(self, *a, **k):
+        self.calls.append((a, k))
+
+
+class CqStub:
+    def __init__(self, data):
+        self.data = data
+        self.answered = False
+        self.edited = []
+        self.message = MsgStub()
+    async def answer(self):
+        self.answered = True
+    async def edit_message_text(self, *a, **k):
+        self.edited.append((a, k))
+
+
+def make_ctx():
+    return types.SimpleNamespace(user_data={})
+
+
+@pytest.mark.asyncio
+async def test_manage_import_cities_loads_list():
+    ctx = make_ctx()
+    cq = CqStub("admin_import_cities")
+    update = types.SimpleNamespace(callback_query=cq)
+    with patch("app.bot.handlers.redis_client.smembers", new=AsyncMock(return_value={"תל אביב", "רעננה"})):
+        await handle_admin_manage_import_cities(update, ctx)
+        # Should show list
+        assert cq.edited
+        assert "ערים מוגדרות" in cq.edited[-1][0][0]
+
+
+@pytest.mark.asyncio
+async def test_import_cities_add_flow_and_inputs():
+    ctx = make_ctx()
+    # Start add
+    cq = CqStub("admin_import_cities_add")
+    update_cq = types.SimpleNamespace(callback_query=cq)
+    await handle_admin_import_cities_add(update_cq, ctx)
+    assert ctx.user_data.get("awaiting_import_cities_add") is True
+
+    # Provide input
+    msg = MsgStub(text="רעננה, הרצליה\nכפר סבא")
+    update_msg = types.SimpleNamespace(message=msg)
+    with patch("app.bot.handlers.redis_client.sadd", new=AsyncMock(return_value=3)):
+        with patch("app.bot.handlers.redis_client.smembers", new=AsyncMock(return_value={"רעננה", "הרצליה", "כפר סבא"})):
+            await handle_admin_import_cities_inputs(update_msg, ctx)
+            assert msg.calls
+            assert ctx.user_data.get("awaiting_import_cities_add") is None
+
+
+@pytest.mark.asyncio
+async def test_import_cities_remove_flow_and_inputs():
+    ctx = make_ctx()
+    # Start remove
+    cq = CqStub("admin_import_cities_remove")
+    update_cq = types.SimpleNamespace(callback_query=cq)
+    with patch("app.bot.handlers.redis_client.smembers", new=AsyncMock(return_value={"רעננה", "תל אביב"})):
+        await handle_admin_import_cities_remove(update_cq, ctx)
+    assert ctx.user_data.get("awaiting_import_cities_remove") is True
+
+    # Provide input to remove
+    msg = MsgStub(text="תל אביב\nחיפה")
+    update_msg = types.SimpleNamespace(message=msg)
+    async def fake_srem(key, member):
+        return 1 if member in {"תל אביב"} else 0
+    with patch("app.bot.handlers.redis_client.srem", new=AsyncMock(side_effect=fake_srem)):
+        with patch("app.bot.handlers.redis_client.smembers", new=AsyncMock(return_value={"רעננה"})):
+            await handle_admin_import_cities_inputs(update_msg, ctx)
+            assert msg.calls
+            assert ctx.user_data.get("awaiting_import_cities_remove") is None
+
+
+@pytest.mark.asyncio
+async def test_import_cities_run_summarizes():
+    ctx = make_ctx()
+    cq = CqStub("admin_import_cities_run")
+    update_cq = types.SimpleNamespace(callback_query=cq)
+    with patch("app.bot.handlers.redis_client.smembers", new=AsyncMock(return_value={"רעננה"})):
+        # Mock Google service and DB
+        class _DummyGoogle:
+            async def __aenter__(self):
+                return self
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+            async def search_veterinary_clinics(self, city):
+                return [{"name": "VetX", "place_id": "px"}]
+            async def search_animal_shelters(self, city):
+                return []
+        class _FakeSession:
+            async def __aenter__(self):
+                return self
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+            async def execute(self, *a, **k):
+                class _R:
+                    def scalar_one_or_none(self_inner):
+                        return None
+                return _R()
+            def add(self, *a, **k):
+                return None
+            async def commit(self):
+                return None
+        with patch("app.bot.handlers.GoogleService", return_value=_DummyGoogle()):
+            with patch("app.bot.handlers.async_session_maker", return_value=_FakeSession()):
+                await handle_admin_import_cities_run(update_cq, ctx)
+                # Should edit summary text with totals
+                assert cq.edited
+                assert "ייבוא הושלם" in cq.edited[-1][0][0]
+

--- a/tests/test_report_flow.py
+++ b/tests/test_report_flow.py
@@ -1,0 +1,109 @@
+import types
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from telegram.ext import ConversationHandler
+
+from app.bot.handlers import (
+    WAITING_FOR_PHOTO,
+    WAITING_FOR_LOCATION,
+    WAITING_FOR_DESCRIPTION,
+    CONFIRMING_REPORT,
+    SELECTING_URGENCY,
+    SELECTING_ANIMAL_TYPE,
+    create_report_conversation_handler,
+    handle_photo_upload,
+    request_location,
+    handle_location,
+    handle_description,
+    handle_report_confirmation,
+    show_urgency_selection,
+    show_animal_type_selection,
+)
+
+
+class PhotoFileStub:
+    def __init__(self, content: bytes = b"abc"):
+        self._content = content
+    async def download_to_memory(self, buf):
+        buf.write(self._content)
+
+class PhotoStub:
+    def __init__(self):
+        self.file_id = "file_1"
+        self.file_size = 123
+        self.width = 100
+        self.height = 100
+    async def get_file(self):
+        return PhotoFileStub()
+
+class MsgStub:
+    def __init__(self, text=None, photo=None, location=None):
+        self.text = text
+        self.photo = photo or []
+        self.location = location
+        self.calls = []
+    async def reply_text(self, *a, **k):
+        self.calls.append((a, k))
+
+
+def make_update_message(**kwargs):
+    return types.SimpleNamespace(message=MsgStub(**kwargs), effective_user=None, effective_chat=None)
+
+
+@pytest.mark.asyncio
+async def test_report_flow_photo_to_location():
+    # Upload photo leads to WAITING_FOR_LOCATION via request_location
+    msg = MsgStub(photo=[PhotoStub()])
+    update = types.SimpleNamespace(message=msg, effective_user=None, effective_chat=None)
+    with patch("app.bot.handlers.set_typing_action", new=AsyncMock()):
+        # Patch storage functions used indirectly
+        with patch("app.bot.handlers.file_storage_service.save_temp_file", new=AsyncMock(return_value="/tmp/x.jpg")):
+            state = await handle_photo_upload(update, types.SimpleNamespace(user_data={}))
+            assert state == WAITING_FOR_LOCATION
+            # request_location sends a message; ensure at least one reply in photo handler
+            assert msg.calls
+
+
+@pytest.mark.asyncio
+async def test_report_flow_location_to_description():
+    # Provide manual address text triggers location handling and moves to description stage
+    ctx = types.SimpleNamespace(user_data={"report_draft": {}})
+    # Simulate location text where handler expects location or text (it supports text path too)
+    update = make_update_message(text="רחוב הבנים 10, רעננה")
+    with patch("app.bot.handlers.set_typing_action", new=AsyncMock()):
+        # Patch geocoding to return city/address
+        with patch("app.bot.handlers.geocoding_service.geocode", new=AsyncMock(return_value={"address": "רחוב הבנים 10", "city": "רעננה"})):
+            state = await handle_location(update, ctx)
+            # Handler can stay WAITING_FOR_LOCATION if cannot parse; accept either
+            assert state in (WAITING_FOR_LOCATION, WAITING_FOR_DESCRIPTION)
+
+
+@pytest.mark.asyncio
+async def test_report_flow_description_short_then_ok():
+    ctx = types.SimpleNamespace(user_data={"report_draft": {}})
+    # Short description -> stays in WAITING_FOR_DESCRIPTION
+    update_short = make_update_message(text="קצר מידי")
+    state = await handle_description(update_short, ctx)
+    assert state == WAITING_FOR_DESCRIPTION
+    # Valid description -> proceeds towards confirmation
+    with patch("app.bot.handlers.set_typing_action", new=AsyncMock()):
+        with patch("app.bot.handlers.nlp_service.analyze_text", new=AsyncMock(return_value={"urgency": None, "animal_type": None, "keywords": []})):
+            update_ok = make_update_message(text="כלב פצוע באמצע הכביש, נראה מדמם")
+            state2 = await handle_description(update_ok, ctx)
+            assert state2 in (CONFIRMING_REPORT, SELECTING_URGENCY, SELECTING_ANIMAL_TYPE)
+
+
+@pytest.mark.asyncio
+async def test_report_flow_confirmation_paths():
+    ctx = types.SimpleNamespace(user_data={"report_draft": {"description": "x"}})
+    # Modify urgency path
+    cq = types.SimpleNamespace(data="modify_urgency")
+    update = types.SimpleNamespace(callback_query=cq, effective_user=None, effective_chat=None)
+    res = await handle_report_confirmation(update, ctx)
+    assert res == SELECTING_URGENCY
+    # Modify animal type path
+    cq2 = types.SimpleNamespace(data="modify_animal_type")
+    update2 = types.SimpleNamespace(callback_query=cq2, effective_user=None, effective_chat=None)
+    res2 = await handle_report_confirmation(update2, ctx)
+    assert res2 == SELECTING_ANIMAL_TYPE

--- a/tests/test_report_flow.py
+++ b/tests/test_report_flow.py
@@ -103,6 +103,8 @@ async def test_report_flow_confirmation_paths():
             self.data = data
         async def answer(self):
             return None
+        async def edit_message_text(self, *args, **kwargs):
+            return None
     cq = CQ("modify_urgency")
     update = types.SimpleNamespace(callback_query=cq, effective_user=None, effective_chat=None)
     res = await handle_report_confirmation(update, ctx)


### PR DESCRIPTION
<h2>תקציר</h2>
<p>
תיקון תקיעת הזרימות בבוט לאחר הכנסת אימייל/עיר, הוספת ConversationHandlers מסודרים, שיפורי i18n ולוגים, דדופ בייבוא, והקמת תשתית CI מלאה (Postgres+PostGIS, יצירת סכימה, והרצת טסטים). ה‑CI ירוק.
</p>

<h2>שינויים עיקריים</h2>
<ul>
  <li><b>זרימות הבוט (Telegram):</b>
    <ul>
      <li>הוספת ConversationHandler ל״הוסף ארגון״: <i>name → type → email</i> עם החזרת state נכונה בכל שלב.</li>
      <li>ייבוא מגוגל לפי עיר: state לקליטת עיר, דדופ לפי <code>place_id</code>, סיום שיחה ב‑END על שגיאה.</li>
      <li>ייבוא לפי מיקום: בחירת רדיוס (5/10/20/50 ק״מ), ברירת מחדל 10 ק״מ, תמיכה ב‑LOCATION, ניקוי מקלדת בסיום.</li>
      <li>הסרת MessageHandlers מתנגשים ומעבר מלא ל־ConversationHandlers.</li>
      <li>לוגים משופרים עם <code>enter state=...</code> ופרטי update מלאים (text/callback/location).</li>
    </ul>
  </li>
  <li><b>i18n ו־UX:</b>
    <ul>
      <li>הודעות שגיאה בעברית (״כתובת אימייל לא תקינה״, ״קלט לא תקין״), הנחיות אימייל אחרי בחירת סוג.</li>
      <li>ב־handle_language_selection: נפילות־לאחור אם חסר <code>first_name</code> (משתמש ב‑full_name/username), שמירת השפה גם תחת <code>user_data["language"]</code>.</li>
    </ul>
  </li>
  <li><b>דדופ בייבוא:</b> סינון כפילויות בזיכרון לפי <code>place_id</code> לפני בדיקת קיום ב‑DB, למניעת הוספות כפולות.</li>
  <li><b>Webhook:</b> לוגים מורחבים, אימות סוד (אם מוגדר), טיפול שקט בשגיאות (200 OK למניעת retry אגרסיבי).</li>
</ul>

<h2>CI/CD</h2>
<ul>
  <li>הוספת שירות Postgres עם PostGIS: <code>postgis/postgis:14-3.3</code>.</li>
  <li>אתחול סכימה לפני טסטים באמצעות <code>create_tables()</code>.</li>
  <li>הגדרת <code>PYTHONPATH=$PWD</code> ו‑<code>DATABASE_URL</code> (asyncpg) בכל השלבים.</li>
  <li>הוספת pytest + pytest-asyncio ל־requirements, ו‑pytest.ini להגדרת loop scope.</li>
</ul>

<h2>כיסוי בדיקות (עיקרי)</h2>
<ul>
  <li><b>אדמין:</b> הוסף ארגון (שם→סוג→אימייל), הרשאות (permission_denied), ייבוא עיר/מיקום כולל כישלון/דדופ/רדיוס/ניקוי מקלדת.</li>
  <li><b>Redis:</b> ניהול ערי ייבוא (add/remove/run) עם מוקים ל‑<code>redis_client</code>.</li>
  <li><b>i18n:</b> תפריט שפה, שינוי שפה (שמירה ב־context, הודעות/תפריטים), טקסטי שגיאה בעברית.</li>
  <li><b>זרימת דיווח:</b> תמונות→מיקום→תיאור→אישורים (ענפים ל‑דחיפות/סוג חיה), guardים ותסריטי קצה.</li>
  <li><b>Webhook:</b> סימולציות בסיסיות דרך ה־router (ללא גישה לרשת חיצונית).</li>
</ul>

<h2>סיכוני פריסה והערות</h2>
<ul>
  <li>נדרש PostGIS בסביבת CI/סטייג׳ינג (בפרודקשן כבר קיים/מנוהל).</li>
  <li>אין מיגרציות מסוכנות; יצירת סכימה מתבצעת אוטומטית ב־startup (create_tables).</li>
  <li>בדקו משתני סביבה רגישים (טוקן טלגרם/סודות) מוגדרים בסביבה הרלוונטית.</li>
</ul>

<h2>איך לבדוק ידנית</h2>
<ol>
  <li>להיכנס לבוט → ״🏢 ניהול ארגונים״ → ״➕ הוסף ארגון חדש״:
    <ul>
      <li>הזינו שם → בחרו סוג → הזינו אימייל תקין → צפו בהודעת אישור.</li>
      <li>נסו אימייל לא תקין → צפו בהודעת שגיאה בעברית.</li>
    </ul>
  </li>
  <li>״🔎 ייבוא מגוגל לפי עיר״: הזינו עיר (עברית/אנגלית) → קבלו סיכום. נסו שוב אותה עיר → ודאו שאין כפילויות.</li>
  <li>״📍 ייבוא לפי מיקום״: בחרו רדיוס → שלחו LOCATION → קבלו סיכום וניקוי מקלדת.</li>
  <li>״שינוי שפה״: בחרו אנגלית → תפריטים והודעות באנגלית; חזרה לעברית כנ״ל.</li>
</ol>

<h2>מטלות המשך (מומלץ)</h2>
<ul>
  <li>טסטי E2E נוספים דרך <code>/telegram/webhook/simulate</code> לכיסוי רחב יותר.</li>
  <li>כיסוי תרחישי Quota/Timeout של Google עם fallback ודיווח משתמש.</li>
  <li>חיזוק בדיקות i18n לכל המפתחות הקריטיים בכל השפות.</li>
</ul>

<h2>צ׳ק-ליסט</h2>
<ul>
  <li>✔ CI ירוק (כולל DB+PostGIS).</li>
  <li>✔ אין קריאות לרשת חיצונית בטסטים (מוקים בלבד).</li>
  <li>✔ אין מחיקות מסוכנות לקבצים; היכן שיש – ניקוי בטוח בלבד.</li>
  <li>✔ שגיאות בוט לוגיות תורגמו להחזרת state/END והודעה למשתמש.</li>
</ul>

---
<a href="https://cursor.com/background-agent?bcId=bc-febd7fe4-4242-4736-9ce7-214624166fc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-febd7fe4-4242-4736-9ce7-214624166fc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

