### PR TITLE
Check veterinary care report routing

### DIFF
--- a/app/workers/jobs.py
+++ b/app/workers/jobs.py
@@ -380,9 +380,17 @@ async def _find_organizations_by_type(
             conditions.append(Organization.city.ilike(f"%{city}%"))
         
         # Add specialty filter
+        # הוספת מילות מפתח כלליות לווטרינרים מבטיחה שארגונים עם תגיות כמו
+        # 'veterinary_care' / 'veterinary' / 'animal_hospital' ייכללו גם כשזוהה כלב/חתול
         animal_keywords = {
-            AnimalType.DOG: ["dog", "dogs", "כלב", "כלבים"],
-            AnimalType.CAT: ["cat", "cats", "חתול", "חתולים"], 
+            AnimalType.DOG: [
+                "dog", "dogs", "כלב", "כלבים",
+                "vet", "veterinary", "veterinary_care", "animal_hospital", "emergency_vet"
+            ],
+            AnimalType.CAT: [
+                "cat", "cats", "חתול", "חתולים",
+                "vet", "veterinary", "veterinary_care", "animal_hospital", "emergency_vet"
+            ], 
             AnimalType.BIRD: ["bird", "birds", "צפור", "צפורים"],
             AnimalType.WILDLIFE: ["wildlife", "wild", "חיות בר"],
         }


### PR DESCRIPTION
Expand `animal_keywords` for `DOG` and `CAT` to include general veterinary terms.

This change ensures that organizations with `specialties` like `veterinary_care` or `animal_hospital` will receive alerts for reports mentioning "dog" or "cat", even if "dog" or "cat" are not explicitly listed in their specialties. Previously, a `veterinary_care` specialty alone would not match a "dog" report.

---
<a href="https://cursor.com/background-agent?bcId=bc-46d8e54d-9bf3-4f1c-8f26-ca4b986ab314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-46d8e54d-9bf3-4f1c-8f26-ca4b986ab314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

